### PR TITLE
save in png format

### DIFF
--- a/src/cr_renderer/image_utils.py
+++ b/src/cr_renderer/image_utils.py
@@ -13,7 +13,6 @@ def encode_surface(surface: skia.Surface, format: str) -> bytes:
 
 
 def encode_skia_image(image: skia.Image, format: str) -> bytes:
-    print(format)
     """Convert skia.Image to bytes."""
     formats = dict(png=skia.kPNG, jpeg=skia.kJPEG)
     with io.BytesIO() as f:

--- a/src/cr_renderer/image_utils.py
+++ b/src/cr_renderer/image_utils.py
@@ -13,6 +13,7 @@ def encode_surface(surface: skia.Surface, format: str) -> bytes:
 
 
 def encode_skia_image(image: skia.Image, format: str) -> bytes:
+    print(format)
     """Convert skia.Image to bytes."""
     formats = dict(png=skia.kPNG, jpeg=skia.kJPEG)
     with io.BytesIO() as f:

--- a/src/cr_renderer/renderer.py
+++ b/src/cr_renderer/renderer.py
@@ -52,11 +52,12 @@ class CrelloV5Renderer(_BaseRenderer):
         example: Dict[str, Any],
         max_size: int = 360,
         render_text: bool = True,
+        format: str = "jpeg",
     ) -> bytes:
         """Render a preprocessed example and return as JPEG bytes."""
         example = _decode_class_label(self.features, example)
         # TODO: validate the example against the pydantic schema.
-        return _render_to_surface(self.font_manager, example, max_size, render_text)
+        return _render_to_surface(self.font_manager, example, max_size, render_text, format)
 
 
 class CrelloV4Renderer(_BaseRenderer):
@@ -79,11 +80,12 @@ class CrelloV4Renderer(_BaseRenderer):
         example: Dict[str, Any],
         max_size: int = 360,
         render_text: bool = True,
+        format: str = "jpeg",
     ) -> bytes:
         """Render a preprocessed example and return as JPEG bytes."""
         example = _decode_class_label(self.features, example)
         example = self.convert_to_v5(example)
-        return _render_to_surface(self.font_manager, example, max_size, render_text)
+        return _render_to_surface(self.font_manager, example, max_size, render_text, format)
 
     @staticmethod
     def convert_to_v5(example: Dict[str, Any]) -> Dict[str, Any]:
@@ -161,6 +163,7 @@ def _render_to_surface(
     example: Dict[str, Any],
     max_size: int,
     render_text: bool = True,
+    format: str = "jpeg",
 ) -> bytes:
     """Render an example to a surface and return as JPEG bytes."""
     canvas_width = example["canvas_width"]
@@ -207,7 +210,7 @@ def _render_to_surface(
                     dst = skia.Rect(example["width"][i], example["height"][i])
                     paint = skia.Paint(Alphaf=example["opacity"][i], AntiAlias=True)
                     canvas.drawImageRect(image, src, dst, paint=paint)
-    return image_utils.encode_surface(surface, "jpeg")
+    return image_utils.encode_surface(surface, format)
 
 
 def _get_scale_size(

--- a/src/cr_renderer/renderer.py
+++ b/src/cr_renderer/renderer.py
@@ -53,11 +53,12 @@ class CrelloV5Renderer(_BaseRenderer):
         max_size: int = 360,
         render_text: bool = True,
         format: str = "jpeg",
+        canvas_color: skia.Color4f | None = skia.ColorWHITE
     ) -> bytes:
         """Render a preprocessed example and return as JPEG bytes."""
         example = _decode_class_label(self.features, example)
         # TODO: validate the example against the pydantic schema.
-        return _render_to_surface(self.font_manager, example, max_size, render_text, format)
+        return _render_to_surface(self.font_manager, example, max_size, render_text, format, canvas_color)
 
 
 class CrelloV4Renderer(_BaseRenderer):
@@ -81,11 +82,12 @@ class CrelloV4Renderer(_BaseRenderer):
         max_size: int = 360,
         render_text: bool = True,
         format: str = "jpeg",
+        canvas_color: skia.Color4f | None = skia.ColorWHITE
     ) -> bytes:
         """Render a preprocessed example and return as JPEG bytes."""
         example = _decode_class_label(self.features, example)
         example = self.convert_to_v5(example)
-        return _render_to_surface(self.font_manager, example, max_size, render_text, format)
+        return _render_to_surface(self.font_manager, example, max_size, render_text, format, canvas_color)
 
     @staticmethod
     def convert_to_v5(example: Dict[str, Any]) -> Dict[str, Any]:
@@ -164,6 +166,7 @@ def _render_to_surface(
     max_size: int,
     render_text: bool = True,
     format: str = "jpeg",
+    canvas_color: skia.Color4f | None = skia.ColorWHITE
 ) -> bytes:
     """Render an example to a surface and return as JPEG bytes."""
     canvas_width = example["canvas_width"]
@@ -172,7 +175,11 @@ def _render_to_surface(
     surface = skia.Surface(size[0], size[1])
     with surface as canvas:
         canvas.scale(scale[0], scale[1])
-        canvas.clear(skia.ColorWHITE)
+
+        # if canvas_color is None, the background is transparent.
+        if canvas_color is not None:
+            canvas.clear(canvas_color)
+
         for i in range(example["length"]):
             with skia.AutoCanvasRestore(canvas):
                 canvas.translate(example["left"][i], example["top"][i])


### PR DESCRIPTION
To extract the alpha layer from images, it would be nice if the image is saved in PNG format.
- [x] : have an option to save in PNG format in [render](https://github.com/CyberAgentAILab/cr-renderer/blob/main/src/cr_renderer/renderer.py#L50-L59)
- [x] : have an option for background fill in render